### PR TITLE
Fix bug and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 streetview-dl is a simple PHP script to download 360 panoramic equirectangular images from Google Street View.  
 
-It downloads with the highest resolution/quality/zoom, the result is a 13000x6500 pixels equirectangular image.
+It downloads with the highest resolution/quality/zoom, the result is a 16120x8060 pixels equirectangular image.
 It also creates a smaller resize images of 8192x4096 pixels and 1300x650.  
 
 Exif tags about 360º image are added automatically.  

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# streeview downloader an opensource Google Street View Equirectangular 360 Panoramic images downloader
+# streetview downloader an opensource Google Street View Equirectangular 360 Panoramic images downloader
 
 ## What it does
 
-streview-dl is a simple PHP script to download 360 panoramic equirectangular images from Google Street View.  
+streetview-dl is a simple PHP script to download 360 panoramic equirectangular images from Google Street View.  
 
 It downloads with the highest resolution/quality/zoom, the result is a 13000x6500 pixels equirectangular image.
 It also creates a smaller resize images of 8192x4096 pixels and 1300x650.  

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This script is made to run over Linux.
 
 e.g:  
 
-    $ php ./streeview-dl.php 'https://www.google.com/maps/@41.3881837,2.1698939,3a,75y,143.45h,92.72t/data=!3m6!1e1!3m4!1sr3vUp9U2ss5fwoq1Roxizw!2e0!7i16384!8i8192'  
+    $ php ./streetview-dl.php 'https://www.google.com/maps/@41.3881837,2.1698939,3a,75y,143.45h,92.72t/data=!3m6!1e1!3m4!1sr3vUp9U2ss5fwoq1Roxizw!2e0!7i16384!8i8192'  
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ e.g:
 
 "montage-im6.q16: cache resources exhausted " can be resolved changing ImageMagick configuration, more info here: https://github.com/ImageMagick/ImageMagick/issues/396  
 
+Sometimes images are garbled! Likely caused by older photos using less tiles than newer ones. Use streetview-dl-oldpics.php instead! ( The older version of the script ) 
+
 ## Viewers
 
 Android: Ricoh Theta App https://play.google.com/store/apps/details?id=com.theta360&hl=en&gl=US  

--- a/streetview-dl-oldpics.php
+++ b/streetview-dl-oldpics.php
@@ -1,0 +1,206 @@
+<?PHP
+
+if (count($argv)!=2) { echo("Syntax: php ./streetview-dl.php <url>\nremember put url between single quotes\n"); exit(0); }
+
+$id = $argv[1];
+
+if (strpos($id, "/")!==false) $id = getIdFromUrl($id);
+
+if (strlen($id)<10 || strlen($id)>30) { echo("wrong id\n"); exit(0); }
+
+echo("pano id: ".$id."\n");
+
+$op_st = new OpSt($id);
+
+//$op_st->printDebug();
+
+$op_st->download();
+
+$pathL = "stl-".$id.".jpg";
+
+echo($pathL." created\n");
+
+echo("resize...\n");
+
+$pathM = "stm-".$id.".jpg";
+resizeEqui($pathL, $pathM, 8192);
+
+echo($pathM." created\n");
+
+$pathS = "sts-".$id.".jpg";
+resizeEqui($pathM, $pathS, 1300);
+
+echo($pathS." created\n");
+
+echo("adding equirectangular pano exif tags\n");
+addExifEqui($pathL, 13000);
+addExifEqui($pathM, 8192);
+addExifEqui($pathS, 1300);
+
+echo("done\n");
+
+function resizeEqui($pathSrc, $pathDst, $width) {
+	$height = $width / 2;
+	exec("convert \"".$pathSrc."\" -resize ".$width."x".$height." -quality 100 \"".$pathDst."\"");
+}
+
+function getIdFromUrl($url) {
+	$fields = explode("!1s", $url);
+	$fields2 = explode("!", $fields[1]);
+	return $fields2[0];
+}
+
+function addExifEqui($path, $width) {
+	$height = $width / 2;
+	exec("exiftool -overwrite_original -UsePanoramaViewer=True -ProjectionType=equirectangular -PoseHeadingDegrees=180.0 -CroppedAreaLeftPixels=0 -FullPanoWidthPixels=".$width." -CroppedAreaImageHeightPixels=".$height." -FullPanoHeightPixels=".$height." -CroppedAreaImageWidthPixels=".$width." -CroppedAreaTopPixels=0 -LargestValidInteriorRectLeft=0 -LargestValidInteriorRectTop=0 -LargestValidInteriorRectWidth=".$width." -LargestValidInteriorRectHeight=".$height." -Model=\"github fdd4s streetview-dl\" \"".$path."\"");
+}
+
+class OpSt {
+	var $op_id;
+	var $op_url_list;
+
+	public function __construct($id) {
+		$this->op_id = new OpId($id);
+		$this->op_url_list = new OpUrlList();
+	}
+
+	public function download() {
+		echo("Downloading...\n");
+		$this->makeImgList();
+		$this->op_url_list->downloadAria2c();
+		echo("Montage...\n");
+		$this->makeMontage();
+		echo("Cleaning temp files...\n");
+		$this->op_url_list->removeFiles();
+	}
+
+	private function makeImgList() {
+		$this->op_url_list->clear();
+
+		$x_ini = 0;
+		$x_fin = 25;
+		$y_ini = 0;
+		$y_fin = 12;
+
+		$num_file = 1;
+
+		$codigo = $this->op_id->getIdSrc();
+		$id = $this->op_id->getIdOp();
+
+		for ($y_act = $y_ini; $y_act <= $y_fin; $y_act++) {
+			for ($x_act = $x_ini; $x_act <= $x_fin; $x_act++) {
+				$url = "https://streetviewpixels-pa.googleapis.com/v1/tile?cb_client=maps_sv.tactile&panoid=".$codigo."&x=".$x_act."&y=".$y_act."&zoom=5&nbt=1&fover=2";
+
+				$file = "tmp-f".$id."_".$num_file.".jpg";
+				$num_file++;
+
+				$this->op_url_list->addUrl($url, $file);
+			}
+		}
+	}
+
+	public function makeMontage() {
+		$file_list_data = "";
+		$id = $this->op_id->getIdOp();
+		$idSrc = $this->op_id->getIdSrc();
+		for ($i=1; $i<339; $i++) {
+			$file_list_data .= "tmp-f".$id."_".$i.".jpg\n";
+		}
+		$file_list_path = dirname(__FILE__)."/tmp-fl".$id.".txt";
+		file_put_contents($file_list_path, $file_list_data);
+
+		$montage_cmd = "montage @".$file_list_path." -tile 26x13 -geometry 500x500+0+0 -quality 100 stl-".$idSrc.".jpg";
+		exec($montage_cmd);		
+		unlink($file_list_path);
+	}
+
+	public function printDebug() {
+		$this->makeImgList();
+		$this->op_url_list->printDebug();
+
+		$this->op_id->printDebug();
+	}
+}
+
+class OpUrlList {
+	var $url_list;
+
+	public function __construct() {
+		$this->url_list = array();
+	}
+
+	public function clear() {
+		unset($this->url_list);
+		$this->url_list = array();
+	}
+
+	public function addUrl($url, $file) {
+		$item = array();
+		$item[] = $url;
+		$item[] = $file;
+		$this->url_list[] = $item;
+	}
+
+	public function downloadAria2c() {
+		$path = $this->makeTmpPath().".txt";
+		file_put_contents($path, $this->makeAria2cList());
+		exec("aria2c -i \"".$path."\"");
+		unlink($path);
+	}
+
+	private function makeAria2cList() {
+		$res = "";
+		foreach ($this->url_list as $item) {
+			$res .= $item[0]."\n";
+			$res .= " out=".$item[1]."\n";
+		}
+		return $res;
+	}
+
+	private function makeTmpPath() {
+		return dirname(__FILE__)."/tmp-".hash('ripemd160', microtime().mt_rand(1, 100000));
+	}
+
+	public function removeFiles() {
+		foreach ($this->url_list as $item) {
+			unlink($item[1]);
+		}
+	}
+
+	public function printDebug() {
+		foreach ($this->url_list as $item) {
+			echo("URL ".$item[0]." File ".$item[1]."\n");
+		}
+	}
+}
+
+class OpId {
+	var $id_src;
+	var $id_op;
+
+	public function __construct($id) {
+		$this->id_src = $id;
+		$this->id_op = $this->makeId($id);
+	}
+
+	private function makeId($id) {
+		$id_hash = hash('ripemd160', $id);
+		$id_crc = hash('crc32b', $id_hash);
+		return "op".$id_hash.$id_crc;
+	}
+
+	public function getIdSrc() {
+		return $this->id_src;
+	}
+
+	public function getIdOp() {
+		return $this->id_op;
+	}
+
+	public function printDebug() {
+		echo("id src: ".$this->id_src."\n");
+		echo("id op: ".$this->id_op."\n");
+	}
+}
+
+?>

--- a/streetview-dl.php
+++ b/streetview-dl.php
@@ -41,7 +41,7 @@ echo("done\n");
 
 function resizeEqui($pathSrc, $pathDst, $width) {
 	$height = $width / 2;
-	exec("convert \"".$pathSrc."\" -resize ".$width."x".$height." -quality 100 \"".$pathDst."\"");
+	exec("magick \"".$pathSrc."\" -resize ".$width."x".$height." -quality 100 \"".$pathDst."\"");
 }
 
 function getIdFromUrl($url) {

--- a/streeview-dl.php
+++ b/streeview-dl.php
@@ -33,7 +33,7 @@ resizeEqui($pathM, $pathS, 1300);
 echo($pathS." created\n");
 
 echo("adding equirectangular pano exif tags\n");
-addExifEqui($pathL, 13000);
+addExifEqui($pathL, 16120);
 addExifEqui($pathM, 8192);
 addExifEqui($pathS, 1300);
 
@@ -78,9 +78,9 @@ class OpSt {
 		$this->op_url_list->clear();
 
 		$x_ini = 0;
-		$x_fin = 25;
+		$x_fin = 31;
 		$y_ini = 0;
-		$y_fin = 12;
+		$y_fin = 15;
 
 		$num_file = 1;
 
@@ -103,13 +103,13 @@ class OpSt {
 		$file_list_data = "";
 		$id = $this->op_id->getIdOp();
 		$idSrc = $this->op_id->getIdSrc();
-		for ($i=1; $i<339; $i++) {
+		for ($i=1; $i<513; $i++) {
 			$file_list_data .= "tmp-f".$id."_".$i.".jpg\n";
 		}
 		$file_list_path = dirname(__FILE__)."/tmp-fl".$id.".txt";
 		file_put_contents($file_list_path, $file_list_data);
 
-		$montage_cmd = "montage @".$file_list_path." -tile 26x13 -geometry 500x500+0+0 -quality 100 stl-".$idSrc.".jpg";
+		$montage_cmd = "montage @".$file_list_path." -tile 32x16 -geometry 500x500+0+0 -quality 100 stl-".$idSrc.".jpg";
 		exec($montage_cmd);		
 		unlink($file_list_path);
 	}


### PR DESCRIPTION
This pr fixes #1 and fixes a typo within the filename of the script, and in the README.MD

The bug originated from not downloading all of the tiles, previously X 25 and Y 12.

Those have changed to 31 and 15 respectively, this allows the script to properly download all tiles.
Also a small tweak to the number limiter for filenames given the tile count is drastically higher, and it works flawlessly now.

Also changed "convert" to "magick" as per the warning thrown in the terminal.